### PR TITLE
Interface Change: For performance, require a tracing state change cal…

### DIFF
--- a/vperfetto-min.h
+++ b/vperfetto-min.h
@@ -42,7 +42,10 @@ enum vperfetto_init_flags {
     VPERFETTO_INIT_FLAG_USE_SYSTEM_BACKEND = 1 << 1,
 };
 
+typedef void (*on_tracing_state_change_t)(bool);
+
 struct vperfetto_min_config {
+    on_tracing_state_change_t on_tracing_state_change;
     enum vperfetto_init_flags init_flags;
     const char* filename;
     uint32_t shmem_size_hint_kb;

--- a/vperfetto_min_unittest.cpp
+++ b/vperfetto_min_unittest.cpp
@@ -50,6 +50,10 @@ static void runTrace(const vperfetto_min_config* config, uint32_t iterations) {
     vperfetto_min_endTracing();
 }
 
+static void sOnTracingStateChange(bool enabled) {
+    fprintf(stderr, "%s: tracing state change: %d\n", __func__, enabled);
+}
+
 TEST(VperfettoMin, Basic) {
     static char trace1FileName[L_tmpnam];
 
@@ -60,7 +64,10 @@ TEST(VperfettoMin, Basic) {
 
     fprintf(stderr, "%s: temp names: %s\n", __func__, trace1FileName);
 
+    int tracingEnabled;
+
     vperfetto_min_config config = {
+        sOnTracingStateChange,
         VPERFETTO_INIT_FLAG_USE_INPROCESS_BACKEND,
         trace1FileName,
     };


### PR DESCRIPTION
…lback

This way, the user can skip all the track event points without crossing
shared library boundaries.