### PR TITLE
Add CPU TSC sync option for merging host and guest traces

### DIFF
--- a/vperfetto.h
+++ b/vperfetto.h
@@ -108,6 +108,9 @@ struct TraceCombineConfig {
     // Overriden by useSpecifiedGuestAbsoluteTime.
     bool useGuestTimeDiff = false;
     uint64_t guestClockTimeDiffNs;
+
+    // Use a tsc offset when deriving time sync between host and guest using rdtsc.
+    int64_t guestTscOffset = 0;
 };
 
 // Reads config.guestFile


### PR DESCRIPTION
This requires both the host and guest traces to contain at least
2 clock_snapshot instances with some time in between. In each
clock_snapshot, there should be a CLOCK_BOOTTIME value and a
synchronized CPU clock value such as rdtsc using clock_id 64.

Since the guest rdtsc is offset, there is a new commandline arg
for passing the guest rdtsc offset, which can be found in debugfs, ie:
/sys/kernel/debug/kvm/2362-27/vcpu0/tsc-offset

For reference, here is a percetto CL that adds rdtsc snapshots:
https://github.com/olvaffe/percetto/commit/9b01df24ccc644214c0847807ba8178241fe64e0