### PR TITLE
don't assume cpu snapshot packets are ordered by timestamp

### DIFF
--- a/vperfetto-sdk.cpp
+++ b/vperfetto-sdk.cpp
@@ -824,9 +824,11 @@ static bool getTraceCpuTimeSync(const std::vector<char>& trace, TraceCpuTimeSync
             }
         }
         if (found.hasData()) {
-            last = found;
-            if (!first.hasData()) {
-                first = last;
+            if (!last.hasData() || found.cpuTime > last.cpuTime) {
+                last = found;
+            }
+            if (!first.hasData() || found.cpuTime < first.cpuTime || first.cpuTime == 0) {
+                first = found;
             }
         }
     }


### PR DESCRIPTION
This causes sync issues for me, although I don't know why they aren't ordered correctly.