### PR TITLE
Add traces

### DIFF
--- a/gtestdownloadCMakeLists.txt.in
+++ b/gtestdownloadCMakeLists.txt.in
@@ -1,5 +1,5 @@
 project(googletest-download NONE)
-
+cmake_minimum_required(VERSION 3.23)
 include(ExternalProject)
 ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git

--- a/vperfetto-min.cpp
+++ b/vperfetto-min.cpp
@@ -48,6 +48,7 @@ static VirtualDeviceTraceConfig sTraceConfig = {
     .guestStartTime = 0,
     .guestTimeDiff = 0,
     .perThreadStorageMb = 1,
+    .addTraces = false;
 };
 
 struct TraceProgress {

--- a/vperfetto.cpp
+++ b/vperfetto.cpp
@@ -56,6 +56,7 @@ static VirtualDeviceTraceConfig sTraceConfig = {
     .guestStartTime = 0,
     .guestTimeDiff = 0,
     .perThreadStorageMb = 1,
+    .addTraces = false;
 };
 
 #define TRACE_STACK_DEPTH_MAX 16

--- a/vperfetto.h
+++ b/vperfetto.h
@@ -40,6 +40,7 @@ struct VirtualDeviceTraceConfig {
     int64_t guestTimeDiff;
     uint32_t perThreadStorageMb;
     bool saving;
+    bool addTraces;
 };
 
 // Workflow:
@@ -113,6 +114,9 @@ struct TraceCombineConfig {
 
     // Merge guest events into host space if true; otherwise merge host events into guest.
     bool mergeGuestIntoHost = false;
+
+    // Simply display the two separate traces in one trace. Do not modify them in any way.
+    bool addTraces;
 };
 
 // Reads config.guestFile

--- a/vperfetto_merge.cpp
+++ b/vperfetto_merge.cpp
@@ -66,6 +66,7 @@ int main(int argc, char** argv) {
     config.useGuestTimeDiff = false;
     config.guestTscOffset = 0;
     config.mergeGuestIntoHost = false;
+    config.addTraces = false;
 
     for (int i = 4; i < argc; ++i) {
         auto arg = std::string(argv[i]);
@@ -87,6 +88,9 @@ int main(int argc, char** argv) {
             }
         } else if (arg == "--merge-guest-into-host") {
             config.mergeGuestIntoHost = true;
+        }
+        } else if (arg == "--add-traces") {
+            config.addTraces = true;
         } else {
             // User specified guest boottime
             uint64_t guestClockBootTimeNs;


### PR DESCRIPTION
Adds a flag so that two traces can be added together, not completely merged. There is no manipulation of the trace packets.